### PR TITLE
Support GHC 9.12

### DIFF
--- a/serdoc-binary/serdoc-binary.cabal
+++ b/serdoc-binary/serdoc-binary.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               serdoc-binary
-version:            0.3.0.0
+version:            0.3.1.0
 synopsis:           `binary` backend for `serdoc`
 -- description:
 license:            Apache-2.0

--- a/serdoc-core/serdoc-core.cabal
+++ b/serdoc-core/serdoc-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               serdoc-core
-version:            0.3.0.0
+version:            0.3.1.0
 synopsis:           Generated documentation of serialization formats
 description:        A set of typeclasses, primitives, combinators, and TH
                     utilities for documenting serialization formats in a mostly

--- a/serdoc-core/serdoc-core.cabal
+++ b/serdoc-core/serdoc-core.cabal
@@ -40,7 +40,7 @@ library
                  , text >=1.1 && <2.2
                  , time >=1.12 && <1.14
                  , template-haskell >=2.16 && <2.24
-                 , th-abstraction >=0.6 && <0.7
+                 , th-abstraction >=0.6 && <0.8
     hs-source-dirs:   src
     default-language: Haskell2010
 


### PR DESCRIPTION
This bumps th-abstraction version to support GHC 9.12 and its `base` package.